### PR TITLE
fix: renamed chrono & BigDecimal aliases

### DIFF
--- a/crates/gelx/src/lib.rs
+++ b/crates/gelx/src/lib.rs
@@ -131,9 +131,9 @@ pub mod exports {
 		if #[cfg(feature = "with_bigdecimal")] {
 			#[cfg_attr(docsrs, doc(cfg(feature = "with_bigdecimal")))]
 			pub use bigdecimal;
-			pub type DecimalAlias = bigdecimal::BigDecimal;
+			pub type BigDecimal = bigdecimal::BigDecimal;
 		} else {
-			pub type DecimalAlias = gel_protocol::model::Decimal;
+ 			pub type BigDecimal = gel_protocol::model::Decimal;
 		}
 	}
 
@@ -141,15 +141,15 @@ pub mod exports {
 		if #[cfg(feature = "with_chrono")] {
 			#[cfg_attr(docsrs, doc(cfg(feature = "with_chrono")))]
 			pub use chrono;
-			pub type DateTimeAlias = chrono::DateTime<chrono::Utc>;
-			pub type LocalDatetimeAlias = chrono::NaiveDateTime;
-			pub type LocalDateAlias = chrono::NaiveDate;
-			pub type LocalTimeAlias = chrono::NaiveTime;
+			pub type DateTime = chrono::DateTime<chrono::Utc>;
+			pub type NaiveDateTime = chrono::NaiveDateTime;
+			pub type NaiveDate = chrono::NaiveDate;
+			pub type NaiveTime = chrono::NaiveTime;
 		} else {
-			pub type DateTimeAlias = gel_protocol::model::Datetime;
-			pub type LocalDatetimeAlias = gel_protocol::model::LocalDatetime;
-			pub type LocalTimeAlias = gel_protocol::model::LocalTime;
-			pub type LocalDateAlias = gel_protocol::model::LocalDate;
+			pub type DateTime = gel_protocol::model::Datetime;
+			pub type NaiveDateTime = gel_protocol::model::LocalDatetime;
+			pub type NaiveDate = gel_protocol::model::LocalTime;
+			pub type NaiveTime = gel_protocol::model::LocalDate;
 		}
 	}
 

--- a/crates/gelx/tests/compile/codegen/case_08_datetime.rs
+++ b/crates/gelx/tests/compile/codegen/case_08_datetime.rs
@@ -13,7 +13,7 @@ pub mod example {
         conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
-    pub type Output = __g::DateTimeAlias;
+    pub type Output = __g::DateTime;
     /// The original query string provided to the macro. Can be reused in your codebase.
     pub const QUERY: &str = "select <datetime>'1999-03-31T15:17:00Z'";
 }

--- a/crates/gelx/tests/compile/codegen/case_17_object_shape.rs
+++ b/crates/gelx/tests/compile/codegen/case_17_object_shape.rs
@@ -22,9 +22,9 @@ pub mod example {
     )]
     #[gel(crate_path = __g::gel_protocol)]
     pub struct OutputWalletsSet {
-        pub created_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub primary: bool,
         pub description: Option<String>,
         pub name: Option<String>,
@@ -41,8 +41,8 @@ pub mod example {
     pub struct Output {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub description: Option<String>,
         pub name: String,
         pub wallets: Vec<OutputWalletsSet>,

--- a/crates/gelx/tests/compile/codegen/case_18_object_shape_with_args.rs
+++ b/crates/gelx/tests/compile/codegen/case_18_object_shape_with_args.rs
@@ -51,9 +51,9 @@ pub mod example {
     )]
     #[gel(crate_path = __g::gel_protocol)]
     pub struct OutputWalletsSet {
-        pub created_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub primary: bool,
         pub description: Option<String>,
         pub name: Option<String>,
@@ -70,8 +70,8 @@ pub mod example {
     pub struct Output {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub description: Option<String>,
         pub name: String,
         pub wallets: Vec<OutputWalletsSet>,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime.snap
@@ -17,7 +17,7 @@ pub mod example {
         conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
-    pub type Output = __g::DateTimeAlias;
+    pub type Output = __g::DateTime;
     /// The original query string provided to the macro. Can be reused in your codebase.
     pub const QUERY: &str = "select <datetime>'1999-03-31T15:17:00Z'";
 }

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime__query_serde.snap
@@ -17,7 +17,7 @@ pub mod example {
         conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
-    pub type Output = __g::DateTimeAlias;
+    pub type Output = __g::DateTime;
     /// The original query string provided to the macro. Can be reused in your codebase.
     pub const QUERY: &str = "select <datetime>'1999-03-31T15:17:00Z'";
 }

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape.snap
@@ -19,9 +19,9 @@ pub mod example {
     pub type Input = ();
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct OutputWalletsSet {
-        pub created_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub primary: bool,
         pub description: Option<String>,
         pub name: Option<String>,
@@ -31,8 +31,8 @@ pub mod example {
     pub struct Output {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub description: Option<String>,
         pub name: String,
         pub wallets: Vec<OutputWalletsSet>,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape__query_serde.snap
@@ -26,9 +26,9 @@ pub mod example {
     )]
     #[gel(crate_path = __g::gel_protocol)]
     pub struct OutputWalletsSet {
-        pub created_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub primary: bool,
         pub description: Option<String>,
         pub name: Option<String>,
@@ -45,8 +45,8 @@ pub mod example {
     pub struct Output {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub description: Option<String>,
         pub name: String,
         pub wallets: Vec<OutputWalletsSet>,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args.snap
@@ -37,9 +37,9 @@ pub mod example {
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct OutputWalletsSet {
-        pub created_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub primary: bool,
         pub description: Option<String>,
         pub name: Option<String>,
@@ -49,8 +49,8 @@ pub mod example {
     pub struct Output {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub description: Option<String>,
         pub name: String,
         pub wallets: Vec<OutputWalletsSet>,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args__query_serde.snap
@@ -55,9 +55,9 @@ pub mod example {
     )]
     #[gel(crate_path = __g::gel_protocol)]
     pub struct OutputWalletsSet {
-        pub created_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub primary: bool,
         pub description: Option<String>,
         pub name: Option<String>,
@@ -74,8 +74,8 @@ pub mod example {
     pub struct Output {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub description: Option<String>,
         pub name: String,
         pub wallets: Vec<OutputWalletsSet>,

--- a/crates/gelx_core/src/utils.rs
+++ b/crates/gelx_core/src/utils.rs
@@ -50,12 +50,12 @@ pub(crate) fn maybe_uuid_to_token_name(uuid: &Uuid, exports_ident: &Ident) -> Op
 		STD_INT64 => Some(quote!(i64)),
 		STD_FLOAT32 => Some(quote!(f32)),
 		STD_FLOAT64 => Some(quote!(f64)),
-		STD_DECIMAL => Some(quote!(#exports_ident::DecimalAlias)),
+		STD_DECIMAL => Some(quote!(#exports_ident::BigDecimal)),
 		STD_BOOL => Some(quote!(bool)),
-		STD_DATETIME | STD_PG_TIMESTAMPTZ => Some(quote!(#exports_ident::DateTimeAlias)),
-		CAL_LOCAL_DATETIME | STD_PG_TIMESTAMP => Some(quote!(#exports_ident::LocalDatetimeAlias)),
-		CAL_LOCAL_DATE | STD_PG_DATE => Some(quote!(#exports_ident::LocalDateAlias)),
-		CAL_LOCAL_TIME => Some(quote!(#exports_ident::LocalTimeAlias)),
+		STD_DATETIME | STD_PG_TIMESTAMPTZ => Some(quote!(#exports_ident::DateTime)),
+		CAL_LOCAL_DATETIME | STD_PG_TIMESTAMP => Some(quote!(#exports_ident::NaiveDateTime)),
+		CAL_LOCAL_DATE | STD_PG_DATE => Some(quote!(#exports_ident::NaiveDate)),
+		CAL_LOCAL_TIME => Some(quote!(#exports_ident::NaiveTime)),
 		STD_DURATION => Some(quote!(#exports_ident::gel_protocol::model::Duration)),
 		CAL_RELATIVE_DURATION => {
 			Some(quote!(#exports_ident::gel_protocol::model::RelativeDuration))
@@ -185,15 +185,15 @@ mod tests {
 	#[case::std_int64(STD_INT64, "i64")]
 	#[case::std_float32(STD_FLOAT32, "f32")]
 	#[case::std_float64(STD_FLOAT64, "f64")]
-	#[case::std_decimal(STD_DECIMAL, "exports::DecimalAlias")]
+	#[case::std_decimal(STD_DECIMAL, "exports::BigDecimal")]
 	#[case::std_bool(STD_BOOL, "bool")]
-	#[case::std_datetime(STD_DATETIME, "exports::DateTimeAlias")]
-	#[case::std_pg_timestamptz(STD_PG_TIMESTAMPTZ, "exports::DateTimeAlias")]
-	#[case::cal_local_datetime(CAL_LOCAL_DATETIME, "exports::LocalDatetimeAlias")]
-	#[case::std_pg_timestamp(STD_PG_TIMESTAMP, "exports::LocalDatetimeAlias")]
-	#[case::cal_local_date(CAL_LOCAL_DATE, "exports::LocalDateAlias")]
-	#[case::std_pg_date(STD_PG_DATE, "exports::LocalDateAlias")]
-	#[case::cal_local_time(CAL_LOCAL_TIME, "exports::LocalTimeAlias")]
+	#[case::std_datetime(STD_DATETIME, "exports::DateTime")]
+	#[case::std_pg_timestamptz(STD_PG_TIMESTAMPTZ, "exports::DateTime")]
+	#[case::cal_local_datetime(CAL_LOCAL_DATETIME, "exports::NaiveDateTime")]
+	#[case::std_pg_timestamp(STD_PG_TIMESTAMP, "exports::NaiveDateTime")]
+	#[case::cal_local_date(CAL_LOCAL_DATE, "exports::NaiveDate")]
+	#[case::std_pg_date(STD_PG_DATE, "exports::NaiveDate")]
+	#[case::cal_local_time(CAL_LOCAL_TIME, "exports::NaiveTime")]
 	#[case::std_duration(STD_DURATION, "exports::gel_protocol::model::Duration")]
 	#[case::cal_relative_duration(
 		CAL_RELATIVE_DURATION,

--- a/examples/gelx_example/src/db/mod.rs
+++ b/examples/gelx_example/src/db/mod.rs
@@ -350,8 +350,8 @@ pub mod select_accounts {
     pub struct OutputUser {
         pub slug: String,
         pub id: __g::uuid::Uuid,
-        pub created_at: __g::DateTimeAlias,
-        pub updated_at: __g::DateTimeAlias,
+        pub created_at: __g::DateTime,
+        pub updated_at: __g::DateTime,
         pub bio: Option<String>,
         pub name: Option<String>,
     }
@@ -364,14 +364,14 @@ pub mod select_accounts {
     #[cfg_attr(feature = "with_query", gel(crate_path = __g::gel_protocol))]
     pub struct Output {
         pub access_token: Option<String>,
-        pub access_token_expires_at: Option<__g::DateTimeAlias>,
-        pub created_at: __g::DateTimeAlias,
+        pub access_token_expires_at: Option<__g::DateTime>,
+        pub created_at: __g::DateTime,
         pub id: __g::uuid::Uuid,
-        pub updated_at: __g::DateTimeAlias,
+        pub updated_at: __g::DateTime,
         pub provider: super::default::AccountProvider,
         pub provider_account_id: String,
         pub refresh_token: Option<String>,
-        pub refresh_token_expires_at: Option<__g::DateTimeAlias>,
+        pub refresh_token_expires_at: Option<__g::DateTime>,
         pub scope: Option<String>,
         pub username: Option<String>,
         pub user: OutputUser,


### PR DESCRIPTION
Some crate's derive macros depend on exact naming of type to provide extra features.
Take for example `utoipa`: it depends on the last part of a path to provide some `ToSchema` implementation for `Decimal` and `DateTime<Utc>`. I think they made this choice because actual type in schema differs: you want to have `String` there instead of schema of actual rust object.

I tried to think of better solution in their macro, however failed to find any.
That's why I am pushing this PR: it shouldn't break anything, because those are internals.
