### PR TITLE
feat(codegen): unify generated `query` and `transaction` functions with`QueryExecutor` API

### DIFF
--- a/crates/gelx/readme.md
+++ b/crates/gelx/readme.md
@@ -82,17 +82,10 @@ pub mod example {
 	use ::gelx::exports as __g;
 	/// Execute the desired query.
 	pub async fn query(
-		client: &__g::gel_tokio::Client,
+		client: impl __g::gel_tokio::QueryExecutor,
 		props: &Input,
 	) -> ::core::result::Result<Output, __g::gel_errors::Error> {
 		client.query_required_single(QUERY, props).await
-	}
-	/// Compose the query as part of a larger transaction.
-	pub async fn transaction(
-		conn: &mut __g::gel_tokio::Transaction,
-		props: &Input,
-	) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-		conn.query_required_single(QUERY, props).await
 	}
 	#[derive(
 		Clone,
@@ -166,7 +159,9 @@ async fn main() -> Result<(), Error> {
 				let input = select_user::Input {
 					slug: String::from("test"),
 				};
-				let output = select_user::transaction(&mut txn, &input).await?;
+
+				let output = select_user::query(&mut txn, &input).await?;
+				
 				Ok(output)
 			}
 		})

--- a/crates/gelx/tests/compile/codegen/case_01_str.rs
+++ b/crates/gelx/tests/compile/codegen/case_01_str.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = String;

--- a/crates/gelx/tests/compile/codegen/case_02_bool.rs
+++ b/crates/gelx/tests/compile/codegen/case_02_bool.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = bool;

--- a/crates/gelx/tests/compile/codegen/case_03_int64.rs
+++ b/crates/gelx/tests/compile/codegen/case_03_int64.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = i64;

--- a/crates/gelx/tests/compile/codegen/case_04_float64.rs
+++ b/crates/gelx/tests/compile/codegen/case_04_float64.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = f64;

--- a/crates/gelx/tests/compile/codegen/case_05_bigint.rs
+++ b/crates/gelx/tests/compile/codegen/case_05_bigint.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::BigIntAlias;

--- a/crates/gelx/tests/compile/codegen/case_06_decimal.rs
+++ b/crates/gelx/tests/compile/codegen/case_06_decimal.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::BigIntAlias;

--- a/crates/gelx/tests/compile/codegen/case_07_uuid.rs
+++ b/crates/gelx/tests/compile/codegen/case_07_uuid.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::uuid::Uuid;

--- a/crates/gelx/tests/compile/codegen/case_08_datetime.rs
+++ b/crates/gelx/tests/compile/codegen/case_08_datetime.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::DateTimeAlias;

--- a/crates/gelx/tests/compile/codegen/case_09_duration.rs
+++ b/crates/gelx/tests/compile/codegen/case_09_duration.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::gel_protocol::model::Duration;

--- a/crates/gelx/tests/compile/codegen/case_10_array.rs
+++ b/crates/gelx/tests/compile/codegen/case_10_array.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = Vec<i64>;

--- a/crates/gelx/tests/compile/codegen/case_11_tuple.rs
+++ b/crates/gelx/tests/compile/codegen/case_11_tuple.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = (String, i64, bool);

--- a/crates/gelx/tests/compile/codegen/case_12_named_tuple.rs
+++ b/crates/gelx/tests/compile/codegen/case_12_named_tuple.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/compile/codegen/case_13_set.rs
+++ b/crates/gelx/tests/compile/codegen/case_13_set.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = String;

--- a/crates/gelx/tests/compile/codegen/case_14_empty_set.rs
+++ b/crates/gelx/tests/compile/codegen/case_14_empty_set.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = i64;

--- a/crates/gelx/tests/compile/codegen/case_15_input_shape.rs
+++ b/crates/gelx/tests/compile/codegen/case_15_input_shape.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/compile/codegen/case_16_input_shape_with_args.rs
+++ b/crates/gelx/tests/compile/codegen/case_16_input_shape_with_args.rs
@@ -2,17 +2,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/compile/codegen/case_17_object_shape.rs
+++ b/crates/gelx/tests/compile/codegen/case_17_object_shape.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/compile/codegen/case_18_object_shape_with_args.rs
+++ b/crates/gelx/tests/compile/codegen/case_18_object_shape_with_args.rs
@@ -2,17 +2,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/compile/codegen/case_19_enums.rs
+++ b/crates/gelx/tests/compile/codegen/case_19_enums.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/compile/codegen/case_20_types_query.rs
+++ b/crates/gelx/tests/compile/codegen/case_20_types_query.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/compile/codegen/case_21_bytes.rs
+++ b/crates/gelx/tests/compile/codegen/case_21_bytes.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::bytes::Bytes;

--- a/crates/gelx/tests/compile/codegen/case_22_geometry.rs
+++ b/crates/gelx/tests/compile/codegen/case_22_geometry.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::Geometry;

--- a/crates/gelx/tests/compile/codegen/case_23_geography.rs
+++ b/crates/gelx/tests/compile/codegen/case_23_geography.rs
@@ -2,15 +2,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::Geography;

--- a/crates/gelx/tests/compile/codegen/case_24_custom_scalar.rs
+++ b/crates/gelx/tests/compile/codegen/case_24_custom_scalar.rs
@@ -2,17 +2,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/compile/codegen/insert_user.rs
+++ b/crates/gelx/tests/compile/codegen/insert_user.rs
@@ -2,17 +2,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/compile/codegen/remove_user.rs
+++ b/crates/gelx/tests/compile/codegen/remove_user.rs
@@ -2,17 +2,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/query.rs
+++ b/crates/gelx/tests/query.rs
@@ -179,11 +179,11 @@ pub async fn run_transaction() -> GelxCoreResult<()> {
 				.bio("another bio of class")
 				.slug("test_transaction")
 				.build();
-			let result = insert_user::transaction(&mut tx, &insert_props).await?;
+			let result = insert_user::query(&mut tx, &insert_props).await?;
 
 			// cleanup
 			let remove_props = remove_user::Input::builder().id(result.id).build();
-			remove_user::transaction(&mut tx, &remove_props).await?;
+			remove_user::query(&mut tx, &remove_props).await?;
 
 			Ok(result)
 		}

--- a/crates/gelx/tests/snapshots/codegen__codegen_files@insert_user.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_files@insert_user.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct Input {

--- a/crates/gelx/tests/snapshots/codegen__codegen_files@insert_user__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_files@insert_user__query_serde.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/snapshots/codegen__codegen_files@remove_user.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_files@remove_user.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct Input {

--- a/crates/gelx/tests/snapshots/codegen__codegen_files@remove_user__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_files@remove_user__query_serde.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_01_str.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_01_str.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = String;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_01_str__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_01_str__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = String;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_02_bool.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_02_bool.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = bool;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_02_bool__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_02_bool__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = bool;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_03_int64.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_03_int64.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = i64;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_03_int64__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_03_int64__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = i64;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_04_float64.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_04_float64.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = f64;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_04_float64__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_04_float64__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = f64;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_05_bigint.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_05_bigint.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::BigIntAlias;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_05_bigint__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_05_bigint__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::BigIntAlias;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_06_decimal.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_06_decimal.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::BigIntAlias;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_06_decimal__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_06_decimal__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::BigIntAlias;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_07_uuid.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_07_uuid.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::uuid::Uuid;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_07_uuid__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_07_uuid__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::uuid::Uuid;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::DateTimeAlias;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_08_datetime__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::DateTimeAlias;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_09_duration.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_09_duration.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::gel_protocol::model::Duration;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_09_duration__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_09_duration__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::gel_protocol::model::Duration;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_10_array.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_10_array.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = Vec<i64>;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_10_array__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_10_array__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = Vec<i64>;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_11_tuple.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_11_tuple.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = (String, i64, bool);

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_11_tuple__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_11_tuple__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = (String, i64, bool);

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_12_named_tuple.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_12_named_tuple.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_12_named_tuple__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_12_named_tuple__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_13_set.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_13_set.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = String;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_13_set__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_13_set__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = String;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_14_empty_set.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_14_empty_set.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = i64;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_14_empty_set__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_14_empty_set__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = i64;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_15_input_shape.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_15_input_shape.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(::std::fmt::Debug, ::core::clone::Clone, ::core::marker::Copy)]

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_15_input_shape__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_15_input_shape__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_16_input_shape_with_args.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_16_input_shape_with_args.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct Input {

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_16_input_shape_with_args__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_16_input_shape_with_args__query_serde.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_17_object_shape__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct Input {

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_18_object_shape_with_args__query_serde.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_19_enums.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_19_enums.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(::std::fmt::Debug, ::core::clone::Clone, ::core::marker::Copy)]

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_19_enums__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_19_enums__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_20_types_query.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_20_types_query.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_20_types_query__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_20_types_query__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, &()).await
     }
     pub type Input = ();
     #[derive(

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_21_bytes.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_21_bytes.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::bytes::Bytes;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_21_bytes__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_21_bytes__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::bytes::Bytes;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_22_geometry.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_22_geometry.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::Geometry;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_22_geometry__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_22_geometry__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::Geometry;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_23_geography.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_23_geography.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::Geography;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_23_geography__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_23_geography__query_serde.snap
@@ -6,15 +6,9 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = __g::Geography;

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_24_custom_scalar.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_24_custom_scalar.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone)]
     pub struct Input {

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_24_custom_scalar__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_24_custom_scalar__query_serde.snap
@@ -6,17 +6,10 @@ pub mod example {
     use ::gelx::exports as __g;
     /// Execute the desired query.
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(
         ::std::fmt::Debug,

--- a/crates/gelx_build/tests/snapshots/build__build.snap
+++ b/crates/gelx_build/tests/snapshots/build__build.snap
@@ -7,7 +7,6 @@ output_path = "src/db"
 input_struct_name = "Input"
 output_struct_name = "Output"
 query_function_name = "query"
-transaction_function_name = "transaction"
 query_constant_name = "QUERY"
 exports_alias = "__g"
 struct_derive_macros = ["::std::fmt::Debug", "::core::clone::Clone"]

--- a/crates/gelx_build/tests/snapshots/build__build_sync.snap
+++ b/crates/gelx_build/tests/snapshots/build__build_sync.snap
@@ -7,7 +7,6 @@ output_path = "src/db"
 input_struct_name = "Input"
 output_struct_name = "Output"
 query_function_name = "query"
-transaction_function_name = "transaction"
 query_constant_name = "QUERY"
 exports_alias = "__g"
 struct_derive_macros = ["::std::fmt::Debug", "::core::clone::Clone"]

--- a/crates/gelx_core/src/metadata.rs
+++ b/crates/gelx_core/src/metadata.rs
@@ -55,9 +55,6 @@ pub struct GelxMetadata {
 	#[builder(default = default_query_function_name())]
 	#[serde(default = "default_query_function_name")]
 	pub query_function_name: String,
-	#[builder(default = default_transaction_function_name())]
-	#[serde(default = "default_transaction_function_name")]
-	pub transaction_function_name: String,
 	#[builder(default = default_query_constant_name())]
 	#[serde(default = "default_query_constant_name")]
 	pub query_constant_name: String,
@@ -193,9 +190,6 @@ impl GelxMetadata {
 		format_ident!("{}", self.query_function_name)
 	}
 
-	pub fn transaction_function_ident(&self) -> Ident {
-		format_ident!("{}", self.transaction_function_name)
-	}
 
 	pub fn exports_alias_ident(&self) -> Ident {
 		format_ident!("{}", self.exports_alias)
@@ -258,10 +252,6 @@ fn default_output_struct_name() -> String {
 
 fn default_query_function_name() -> String {
 	"query".to_string()
-}
-
-fn default_transaction_function_name() -> String {
-	"transaction".to_string()
 }
 
 fn default_query_constant_name() -> String {

--- a/examples/gelx_example/src/db/mod.rs
+++ b/examples/gelx_example/src/db/mod.rs
@@ -55,16 +55,9 @@ pub mod auth_allowed_redirect_urls {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
     ) -> ::core::result::Result<(), __g::gel_errors::Error> {
         client.execute(QUERY, &()).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-    ) -> ::core::result::Result<(), __g::gel_errors::Error> {
-        conn.execute(QUERY, &()).await
     }
     pub type Input = ();
     pub type Output = ();
@@ -76,18 +69,10 @@ pub mod insert_location {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(
@@ -133,18 +118,10 @@ pub mod insert_position {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(
@@ -188,18 +165,10 @@ pub mod insert_user {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
         client.query_required_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Output, __g::gel_errors::Error> {
-        conn.query_required_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(
@@ -250,18 +219,10 @@ pub mod remove_user {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(
@@ -304,18 +265,10 @@ pub mod select_accounts {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
         client.query(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
-        conn.query(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(
@@ -384,18 +337,10 @@ pub mod select_test_user {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(
@@ -439,18 +384,10 @@ pub mod select_user {
     /// Execute the desired query.
     #[cfg(feature = "with_query")]
     pub async fn query(
-        client: &__g::gel_tokio::Client,
+        client: impl __g::gel_tokio::QueryExecutor,
         props: &Input,
     ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
         client.query_single(QUERY, props).await
-    }
-    /// Compose the query as part of a larger transaction.
-    #[cfg(feature = "with_query")]
-    pub async fn transaction(
-        conn: &mut __g::gel_tokio::Transaction,
-        props: &Input,
-    ) -> ::core::result::Result<Option<Output>, __g::gel_errors::Error> {
-        conn.query_single(QUERY, props).await
     }
     #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
     #[cfg_attr(


### PR DESCRIPTION
There is no point in generating separate `query` and `transaction` functions, when `QueryExecutor` is available