### PR TITLE
feat(codegen): support failable query args

### DIFF
--- a/crates/gelx/Cargo.toml
+++ b/crates/gelx/Cargo.toml
@@ -22,21 +22,33 @@ bigdecimal = { workspace = true, default-features = true, optional = true }
 bytes = { workspace = true, default-features = true }
 cfg-if = { workspace = true, default-features = true }
 chrono = { workspace = true, default-features = true, optional = true }
-derive_more = { workspace = true, default-features = true, features = ["from", "into", "deref", "deref_mut"] }
+derive_more = { workspace = true, default-features = true, features = [
+	"from",
+	"into",
+	"deref",
+	"deref_mut",
+] }
 document-features = { workspace = true, default-features = true }
 gel-derive = { workspace = true, default-features = true, optional = true }
 gel-errors = { workspace = true, default-features = true }
 gel-protocol = { workspace = true, default-features = true }
-gel-tokio = { workspace = true, default-features = true, features = ["unstable", "derive"], optional = true }
+gel-tokio = { workspace = true, default-features = true, features = [
+	"unstable",
+	"derive",
+], optional = true }
 gelx_macros = { workspace = true, default-features = true }
 geo = { workspace = true, default-features = true, optional = true }
 geo-traits = { workspace = true, default-features = true, optional = true }
 geo-types = { workspace = true, default-features = true, optional = true }
 num-bigint = { workspace = true, default-features = true, optional = true }
 num-traits = { workspace = true, default-features = true, optional = true }
-serde = { workspace = true, default-features = true, features = ["derive"], optional = true }
+serde = { workspace = true, default-features = true, features = [
+	"derive",
+], optional = true }
 serde_bytes = { workspace = true, default-features = true, optional = true }
-strum = { workspace = true, default-features = true, features = ["derive"], optional = true }
+strum = { workspace = true, default-features = true, features = [
+	"derive",
+], optional = true }
 typed-builder = { workspace = true, default-features = true, optional = true }
 uuid = { workspace = true, default-features = true }
 wkb = { workspace = true, default-features = true, optional = true }
@@ -44,23 +56,31 @@ wkb = { workspace = true, default-features = true, optional = true }
 [dev-dependencies]
 assert2 = { workspace = true, default-features = true }
 gelx_core = { workspace = true, default-features = true }
-insta = { workspace = true, default-features = true, features = ["ron", "json", "redactions", "filters"] }
+insta = { workspace = true, default-features = true, features = [
+	"ron",
+	"json",
+	"redactions",
+	"filters",
+] }
 proc-macro2 = { workspace = true, default-features = true }
 rstest = { workspace = true, default-features = true }
 rustversion = { workspace = true, default-features = true }
-test-log = { workspace = true, default-features = true, features = ["log", "trace"] }
-tokio = { workspace = true, default-features = true, features = ["time", "test-util", "fs"] }
+test-log = { workspace = true, default-features = true, features = [
+	"log",
+	"trace",
+] }
+tokio = { workspace = true, default-features = true, features = [
+	"time",
+	"test-util",
+	"fs",
+] }
 trybuild = { workspace = true, default-features = true }
 
 [features]
 # ! #### Default
 
 ## The default feature is `with_all`.
-default = [
-	"with_all",
-	"builder",
-	"strum",
-]
+default = ["with_all", "builder", "strum"]
 
 # ! #### Types
 
@@ -69,6 +89,7 @@ with_bigint = [
 	"dep:num-bigint",
 	"dep:num-traits",
 	"gel-protocol/with-num-bigint",
+	"gelx_core/with_bigint",
 ]
 
 ## Use the `bigdecimal` crate.
@@ -77,21 +98,18 @@ with_bigdecimal = [
 	"dep:num-bigint",
 	"dep:num-traits",
 	"gel-protocol/with-bigdecimal",
+	"gelx_core/with_bigdecimal",
 ]
 
 ## Use the `chrono` crate for all dates.
 with_chrono = [
 	"dep:chrono",
 	"gel-protocol/with-chrono",
+	"gelx_core/with_chrono",
 ]
 
 ## Use the `geo-types` crate for all geo types.
-with_geo = [
-	"dep:geo-traits",
-	"dep:geo-types",
-	"dep:geo",
-	"dep:wkb",
-]
+with_geo = ["dep:geo-traits", "dep:geo-types", "dep:geo", "dep:wkb"]
 
 ## Include all additional types. This is included by default. Use `default-features = false` to disable.
 with_all = [
@@ -105,10 +123,7 @@ with_all = [
 # ! #### Behavior
 
 ## Use the `typed-builder` crate to generate the builders for the generated `Input` structs.
-builder = [
-	"dep:typed-builder",
-	"gelx_macros/builder",
-]
+builder = ["dep:typed-builder", "gelx_macros/builder"]
 
 ## Turn on the `query` and `transaction` methods and anything that relies on `gel-tokio`.
 ## The reason to separate this feature is to enable usage of this macro in browser environments
@@ -141,10 +156,7 @@ serde = [
 ## Enable strum for the generated code.
 ##
 ## Adding this feature requires adding the `strum` dependency to your project.
-strum = [
-	"gelx_macros/strum",
-	"dep:strum",
-]
+strum = ["gelx_macros/strum", "dep:strum"]
 
 [lints]
 workspace = true

--- a/crates/gelx/tests/codegen.rs
+++ b/crates/gelx/tests/codegen.rs
@@ -75,6 +75,12 @@ pub fn testname() -> String {
 #[case::geometry("select ext::postgis::makepoint(1.0, 1.0)")]
 #[case::geography("select <ext::postgis::geography>ext::postgis::makepoint(1.0, 1.0)")]
 #[case::custom_scalar("select (insert Simple { position := <default::Position>$position }) {**};")]
+#[cfg_attr(feature = "with_bigdecimal", case::bigdecimal_arg(
+	"select Transaction {*} filter .amount = <decimal>$amount;"
+))]
+#[cfg_attr(feature = "with_chrono", case::datetime_arg(
+	"select CreatedAt {*} filter .created_at = <datetime>$timestamp;"
+))]
 #[tokio::test]
 #[rustversion::attr(not(nightly), ignore = "requires nightly")]
 async fn codegen_literals(testname: String, #[case] query: &str) -> GelxCoreResult<()> {

--- a/crates/gelx/tests/snapshots/codegen__can_generate_aliased_enums@aliased_enums.snap
+++ b/crates/gelx/tests/snapshots/codegen__can_generate_aliased_enums@aliased_enums.snap
@@ -335,6 +335,9 @@ mod team {
 mod test_user {
     use super::*;
 }
+mod transaction {
+    use super::*;
+}
 mod user {
     use super::*;
 }

--- a/crates/gelx/tests/snapshots/codegen__can_generate_aliased_enums@aliased_enums__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__can_generate_aliased_enums@aliased_enums__query_serde.snap
@@ -335,6 +335,9 @@ mod team {
 mod test_user {
     use super::*;
 }
+mod transaction {
+    use super::*;
+}
 mod user {
     use super::*;
 }

--- a/crates/gelx/tests/snapshots/codegen__can_generate_enums@enums.snap
+++ b/crates/gelx/tests/snapshots/codegen__can_generate_enums@enums.snap
@@ -295,6 +295,9 @@ mod team {
 mod test_user {
     use super::*;
 }
+mod transaction {
+    use super::*;
+}
 mod user {
     use super::*;
 }

--- a/crates/gelx/tests/snapshots/codegen__can_generate_enums@enums__query_serde.snap
+++ b/crates/gelx/tests/snapshots/codegen__can_generate_enums@enums__query_serde.snap
@@ -295,6 +295,9 @@ mod team {
 mod test_user {
     use super::*;
 }
+mod transaction {
+    use super::*;
+}
 mod user {
     use super::*;
 }

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_25_bigdecimal_arg.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_25_bigdecimal_arg.snap
@@ -1,0 +1,51 @@
+---
+source: crates/gelx/tests/codegen.rs
+expression: "&content"
+---
+pub mod example {
+    use ::gelx::exports as __g;
+    /// Execute the desired query.
+    pub async fn query(
+        client: &__g::gel_tokio::Client,
+        props: &Input,
+    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
+        client.query(QUERY, props).await
+    }
+    /// Compose the query as part of a larger transaction.
+    pub async fn transaction(
+        conn: &mut __g::gel_tokio::Transaction,
+        props: &Input,
+    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
+        conn.query(QUERY, props).await
+    }
+    #[derive(::std::fmt::Debug, ::core::clone::Clone)]
+    pub struct Input {
+        pub amount: __g::DecimalAlias,
+    }
+    impl __g::gel_protocol::query_arg::QueryArgs for Input {
+        fn encode(
+            &self,
+            encoder: &mut __g::gel_protocol::query_arg::Encoder,
+        ) -> core::result::Result<(), __g::gel_errors::Error> {
+            let map = __g::gel_protocol::named_args! {
+                "amount" => { let value : __g::gel_protocol::model::Decimal = self.amount
+                .clone().try_into().map_err(| e | { <
+                __g::gel_errors::kinds::NumericOutOfRangeError as
+                __g::gel_errors::ErrorKind > ::build() }) ?; value },
+            };
+            map.encode(encoder)
+        }
+    }
+    #[derive(::std::fmt::Debug, ::core::clone::Clone)]
+    pub struct Output {
+        pub created_at: __g::DateTimeAlias,
+        pub id: __g::uuid::Uuid,
+        pub updated_at: __g::DateTimeAlias,
+        pub amount: __g::DecimalAlias,
+        pub confirmed: bool,
+        pub confirmed_at: Option<__g::DateTimeAlias>,
+        pub tx_hash: String,
+    }
+    /// The original query string provided to the macro. Can be reused in your codebase.
+    pub const QUERY: &str = "select Transaction {*} filter .amount = <decimal>$amount;";
+}

--- a/crates/gelx/tests/snapshots/codegen__codegen_literals@case_26_datetime_arg.snap
+++ b/crates/gelx/tests/snapshots/codegen__codegen_literals@case_26_datetime_arg.snap
@@ -1,0 +1,46 @@
+---
+source: crates/gelx/tests/codegen.rs
+expression: "&content"
+---
+pub mod example {
+    use ::gelx::exports as __g;
+    /// Execute the desired query.
+    pub async fn query(
+        client: &__g::gel_tokio::Client,
+        props: &Input,
+    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
+        client.query(QUERY, props).await
+    }
+    /// Compose the query as part of a larger transaction.
+    pub async fn transaction(
+        conn: &mut __g::gel_tokio::Transaction,
+        props: &Input,
+    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
+        conn.query(QUERY, props).await
+    }
+    #[derive(::std::fmt::Debug, ::core::clone::Clone)]
+    pub struct Input {
+        pub timestamp: __g::DateTimeAlias,
+    }
+    impl __g::gel_protocol::query_arg::QueryArgs for Input {
+        fn encode(
+            &self,
+            encoder: &mut __g::gel_protocol::query_arg::Encoder,
+        ) -> core::result::Result<(), __g::gel_errors::Error> {
+            let map = __g::gel_protocol::named_args! {
+                "timestamp" => { let value : __g::gel_protocol::model::DateTime = self
+                .timestamp.clone().try_into().map_err(| e | { <
+                __g::gel_errors::kinds::NumericOutOfRangeError as
+                __g::gel_errors::ErrorKind > ::build() }) ?; value },
+            };
+            map.encode(encoder)
+        }
+    }
+    #[derive(::std::fmt::Debug, ::core::clone::Clone)]
+    pub struct Output {
+        pub id: __g::uuid::Uuid,
+        pub created_at: __g::DateTimeAlias,
+    }
+    /// The original query string provided to the macro. Can be reused in your codebase.
+    pub const QUERY: &str = "select CreatedAt {*} filter .created_at = <datetime>$timestamp;";
+}

--- a/crates/gelx_cli/Cargo.toml
+++ b/crates/gelx_cli/Cargo.toml
@@ -32,6 +32,21 @@ toml = { workspace = true, default-features = true }
 insta = { workspace = true, default-features = true }
 insta-cmd = { workspace = true, default-features = true }
 
+[features]
+default = ["with_bigint", "with_bigdecimal", "with_chrono"]
+
+with_bigint = [
+	"gelx_core/with_bigint",
+]
+
+with_bigdecimal = [
+	"gelx_core/with_bigdecimal",
+]
+
+with_chrono = [
+	"gelx_core/with_chrono",
+]
+
 [lints]
 workspace = true
 

--- a/crates/gelx_core/Cargo.toml
+++ b/crates/gelx_core/Cargo.toml
@@ -16,12 +16,24 @@ description = "Utilities for codegen in the `gelx` crate."
 base64 = { workspace = true, default-features = true }
 bitflags = { workspace = true, default-features = true }
 check_keyword = { workspace = true, default-features = true }
-derive_more = { workspace = true, default-features = true, features = ["from", "into", "into_iterator", "deref", "deref_mut"] }
+derive_more = { workspace = true, default-features = true, features = [
+    "from",
+    "into",
+    "into_iterator",
+    "deref",
+    "deref_mut",
+] }
 futures = { workspace = true, default-features = true }
 gel-derive = { workspace = true, default-features = true }
 gel-errors = { workspace = true, default-features = true }
-gel-protocol = { workspace = true, default-features = true, features = ["all-types", "with-serde"] }
-gel-tokio = { workspace = true, default-features = true, features = ["unstable", "derive"] }
+gel-protocol = { workspace = true, default-features = true, features = [
+    "all-types",
+    "with-serde",
+] }
+gel-tokio = { workspace = true, default-features = true, features = [
+    "unstable",
+    "derive",
+] }
 heck = { workspace = true, default-features = true }
 indexmap = { workspace = true, default-features = true, features = ["serde"] }
 log = { workspace = true, default-features = true }
@@ -35,7 +47,11 @@ serde_with = { workspace = true, default-features = true }
 strum = { workspace = true, default-features = true, features = ["derive"] }
 syn = { workspace = true, default-features = true, features = ["extra-traits"] }
 thiserror = { workspace = true, default-features = true }
-tokio = { workspace = true, default-features = true, features = ["macros", "rt-multi-thread", "process"] }
+tokio = { workspace = true, default-features = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "process",
+] }
 toml = { workspace = true, default-features = true }
 toml_edit = { workspace = true, default-features = true }
 typed-builder = { workspace = true, default-features = true }
@@ -45,13 +61,19 @@ uuid = { workspace = true, default-features = true, features = ["serde"] }
 assert2 = { workspace = true, default-features = true }
 insta = { workspace = true, default-features = true }
 rstest = { workspace = true }
-tokio = { workspace = true, default-features = true, features = ["time", "test-util"] }
+tokio = { workspace = true, default-features = true, features = [
+    "time",
+    "test-util",
+] }
 
 [features]
 query = []
 serde = []
 builder = []
 strum = []
+with_bigdecimal = []
+with_chrono = []
+with_bigint = []
 
 [lints]
 workspace = true

--- a/crates/gelx_core/src/lib.rs
+++ b/crates/gelx_core/src/lib.rs
@@ -240,6 +240,47 @@ impl<'a> ExploreDescriptorProps<'a> {
 	}
 }
 
+#[derive(Default)]
+pub struct ExploreResult {
+	pub token: Option<TokenStream>,
+	pub conversion: ConvertionKind,
+}
+impl ExploreResult {
+	pub fn map<F>(self, f: F) -> Self
+	where
+		F: FnOnce(TokenStream) -> TokenStream,
+	{
+		Self {
+			token: self.token.map(f),
+			..self
+		}
+	}
+}
+impl From<MappedRustType> for ExploreResult {
+	fn from(value: MappedRustType) -> Self {
+		Self {
+			token: Some(value.token),
+			conversion: value.convertion_kind,
+		}
+	}
+}
+impl From<TokenStream> for ExploreResult {
+	fn from(value: TokenStream) -> Self {
+		Self {
+			token: Some(value),
+			conversion: ConvertionKind::Infailable,
+		}
+	}
+}
+impl From<Option<TokenStream>> for ExploreResult {
+	fn from(value: Option<TokenStream>) -> Self {
+		Self {
+			token: value,
+			conversion: ConvertionKind::Infailable,
+		}
+	}
+}
+
 fn explore_descriptor(
 	props @ ExploreDescriptorProps {
 		typedesc,
@@ -251,7 +292,7 @@ fn explore_descriptor(
 		is_macro,
 	}: ExploreDescriptorProps,
 	tokens: &mut TokenStream,
-) -> GelxCoreResult<Option<TokenStream>> {
+) -> GelxCoreResult<ExploreResult> {
 	let root_ident = format_ident!("{root_name}");
 	let exports_ident = metadata.exports_alias_ident();
 	let Some(descriptor) = descriptor else {
@@ -259,7 +300,7 @@ fn explore_descriptor(
 			tokens.extend(quote!(pub type #root_ident = ();));
 		}
 
-		return Ok(None);
+		return Ok(ExploreResult::default());
 	};
 
 	match descriptor {
@@ -271,11 +312,15 @@ fn explore_descriptor(
 				.descriptor(set_descriptor)
 				.root_name(&sub_root_name)
 				.build();
-			let result = explore_descriptor(props, tokens)?.map(|result| quote!(Vec<#result>));
+			let result = explore_descriptor(props, tokens)?.map(|result: TokenStream| quote!(Vec<#result>));
 
 			if is_root {
-				tokens.extend(quote!(pub type #root_ident = #result;));
-				Ok(Some(quote!(#root_ident)))
+				let result_tokens = result.token;
+				tokens.extend(quote!(pub type #root_ident = #result_tokens;));
+				Ok(ExploreResult {
+					token: Some(quote!(#root_ident)),
+					conversion: result.conversion,
+				})
 			} else {
 				Ok(result)
 			}
@@ -292,37 +337,48 @@ fn explore_descriptor(
 				tokens,
 			)?;
 
-			Ok(result)
+			Ok(ExploreResult {
+				token: result,
+				..Default::default()
+			})
 		}
 
 		Descriptor::BaseScalar(base_scalar) => {
-			let result = uuid_to_token_name(&base_scalar.id, &exports_ident);
+			let mut result = uuid_to_token_name(&base_scalar.id, &exports_ident).into();
 
-			if is_root {
-				tokens.extend(quote!(pub type #root_ident = #result;));
-				Ok(Some(quote!(#root_ident)))
-			} else {
-				Ok(Some(result))
+			let ExploreResult { token, .. } = &mut result;
+
+			match is_root {
+				true => {
+					tokens.extend(quote!(pub type #root_ident = #token;));
+					*token = Some(quote!(#root_ident));
+					Ok(result)
+				}
+				false => Ok(result),
 			}
 		}
 
 		Descriptor::Scalar(scalar) => {
 			let Some(module_name) = &scalar.name.as_ref().map(ModuleName::from) else {
-				return Ok(None); // should not happen
+				return Ok(ExploreResult::default()); // should not happen
 			};
 
 			if module_name.is_system_namespace() {
-				let result = uuid_to_token_name(&scalar.id, &exports_ident);
+				let mut result = uuid_to_token_name(&scalar.id, &exports_ident).into();
 
-				if is_root {
-					tokens.extend(quote!(pub type #root_ident = #result;));
-					Ok(Some(quote!(#root_ident)))
-				} else {
-					Ok(Some(result))
+				let ExploreResult { token, .. } = &mut result;
+
+				match is_root {
+					true => {
+						tokens.extend(quote!(pub type #root_ident = #token;));
+						*token = Some(quote!(#root_ident));
+						Ok(result)
+					}
+					false => Ok(result),
 				}
 			} else if is_macro {
 				let Some(base_type_pos) = scalar.base_type_pos else {
-					return Ok(None); // should not happen
+					return Ok(ExploreResult::default()); // should not happen
 				};
 
 				let props = props
@@ -336,7 +392,10 @@ fn explore_descriptor(
 				let module_ident = module_name.modules_path()?;
 				let enum_ident = module_name.name_ident(false);
 
-				Ok(Some(quote!(super::#module_ident::#enum_ident)))
+				Ok(ExploreResult {
+					token: Some(quote!(super::#module_ident::#enum_ident)),
+					..Default::default()
+				})
 			}
 		}
 
@@ -356,16 +415,20 @@ fn explore_descriptor(
 					tokens,
 				)?;
 
-				tuple_tokens.push(result);
+				tuple_tokens.push(result.token);
 			}
 
-			let result = quote!((#tuple_tokens));
+			let mut result = quote!((#tuple_tokens )).into();
 
-			if is_root {
-				tokens.extend(quote!(pub type #root_ident = #result;));
-				Ok(Some(quote!(#root_ident)))
-			} else {
-				Ok(Some(result))
+			let ExploreResult { token, .. } = &mut result;
+
+			match is_root {
+				true => {
+					tokens.extend(quote!(pub type #root_ident = #token;));
+					*token = Some(quote!(#root_ident));
+					Ok(result)
+				}
+				false => Ok(result),
 			}
 		}
 
@@ -380,7 +443,7 @@ fn explore_descriptor(
 				tokens,
 			)?;
 
-			Ok(result)
+			Ok(result.into())
 		}
 
 		Descriptor::Array(array) => {
@@ -391,26 +454,31 @@ fn explore_descriptor(
 				.descriptor(array_descriptor)
 				.root_name(&sub_root_name)
 				.build();
-			let result = explore_descriptor(props, tokens)?.map(|result| quote!(Vec<#result>));
 
-			if is_root {
-				tokens.extend(quote!(pub type #root_ident = #result;));
-				Ok(Some(quote!(#root_ident)))
-			} else {
-				Ok(result)
+			let mut result = explore_descriptor(props, tokens)?.map(|result| quote!(Vec<#result>));
+
+			let ExploreResult { token, .. } = &mut result;
+
+			match is_root {
+				true => {
+					tokens.extend(quote!(pub type #root_ident = #token;));
+					*token = Some(quote!(#root_ident));
+					Ok(result)
+				}
+				false => Ok(result),
 			}
 		}
 
 		Descriptor::Enumeration(enumeration) => {
 			// TODO: support ephemeral enums not defined in the schema
-			let result = if is_macro {
+			let mut result = if is_macro {
 				// Inline the enum in the macro output.
 				explore_enumeration_descriptor(enumeration, metadata, tokens, is_macro)
 			} else {
 				// Otherwise reference the enum from the generated module which this is a part
 				// of.
 				let Some(name) = &enumeration.name else {
-					return Ok(Some(quote!(String)));
+					return Ok(quote!(String).into());
 				};
 
 				let module_name: ModuleName = name.into();
@@ -418,13 +486,18 @@ fn explore_descriptor(
 				let enum_ident = module_name.name_ident(false);
 
 				quote!(super::#module_ident::#enum_ident)
-			};
+			}
+			.into();
 
-			if is_root {
-				tokens.extend(quote!(pub type #root_ident = #result;));
-				Ok(Some(quote!(#root_ident)))
-			} else {
-				Ok(Some(result))
+			let ExploreResult { token, .. } = &mut result;
+
+			match is_root {
+				true => {
+					tokens.extend(quote!(pub type #root_ident = #token;));
+					*token = Some(quote!(#root_ident));
+					Ok(result)
+				}
+				false => Ok(result),
 			}
 		}
 
@@ -439,7 +512,7 @@ fn explore_descriptor(
 				tokens,
 			)?;
 
-			Ok(result)
+			Ok(result.into())
 		}
 
 		Descriptor::Range(range) => {
@@ -450,14 +523,19 @@ fn explore_descriptor(
 				.descriptor(range_descriptor)
 				.root_name(&sub_root_name)
 				.build();
-			let result = explore_descriptor(props, tokens)?
+
+			let mut result = explore_descriptor(props, tokens)?
 				.map(|result| quote!(#exports_ident::gel_protocol::model::Range<#result>));
 
-			if is_root {
-				tokens.extend(quote!(pub type #root_ident = #result;));
-				Ok(Some(quote!(#root_ident)))
-			} else {
-				Ok(result)
+			let ExploreResult { token, .. } = &mut result;
+
+			match is_root {
+				true => {
+					tokens.extend(quote!(pub type #root_ident = #token;));
+					*token = Some(quote!(#root_ident));
+					Ok(result)
+				}
+				false => Ok(result),
 			}
 		}
 
@@ -519,7 +597,7 @@ fn explore_object_shape_descriptor(
 			.is_macro_bool(is_macro)
 			.build();
 		let output = explore_descriptor(sub_props, tokens)?;
-		let output_token = element.wrap(&output);
+		let output_token = element.wrap(&output.token);
 		let serde_annotation = (&safe_name != name).then_some(metadata.features.wrap_annotation(
 			FeatureName::Serde,
 			&quote!(serde(rename = #name)),
@@ -557,7 +635,21 @@ fn explore_object_shape_descriptor(
 		});
 
 		if is_input {
-			impl_named_args.push(quote!(#name => self.#safe_name_ident.clone(),));
+			match output.conversion {
+				ConvertionKind::Fallible { target_token } => {
+					impl_named_args.push(quote! {
+						#name => {
+							let value: #target_token = self.#safe_name_ident.clone().try_into().map_err(|e| {
+								<#exports_ident::gel_errors::kinds::NumericOutOfRangeError as #exports_ident::gel_errors::ErrorKind>::build()
+							})?;
+							value
+						},
+					});
+				}
+				_ => {
+					impl_named_args.push(quote!(#name => self.#safe_name_ident.clone(),));
+				}
+			}
 		}
 	}
 

--- a/dbschema/default.gel
+++ b/dbschema/default.gel
@@ -33,6 +33,23 @@ module default {
 		required position: Position;
 	}
 
+  type Transaction extending CreatedAt, UpdatedAt {
+    required tx_hash: str {
+      constraint exclusive;
+    }
+    required from_wallet: Wallet {
+      on target delete restrict;
+    }
+    required to_wallet: Wallet {
+      on target delete restrict;
+    }
+    required amount: decimal;
+    required confirmed: bool {
+      default := false;
+    }
+    confirmed_at: datetime;
+  }
+
 	type Location extending CreatedAt, UpdatedAt {
 		required point: ext::postgis::geometry;
 		required area: ext::postgis::geography;

--- a/dbschema/migrations/00001-m1um4wm.edgeql
+++ b/dbschema/migrations/00001-m1um4wm.edgeql
@@ -1,4 +1,4 @@
-CREATE MIGRATION m1p3cdncbbuklymorof33l2snlig7ytag6vyt7e3sm3xp2ygiia2gq
+CREATE MIGRATION m1um4wm63tnxpyoegj5xhc6g5vkx2ku7asngljpqdbehql7gyyl45q
     ONTO initial
 {
   CREATE EXTENSION pgcrypto VERSION '1.3';
@@ -139,6 +139,22 @@ CREATE MIGRATION m1p3cdncbbuklymorof33l2snlig7ytag6vyt7e3sm3xp2ygiia2gq
   CREATE TYPE default::Location EXTENDING default::CreatedAt, default::UpdatedAt {
       CREATE REQUIRED PROPERTY area: ext::postgis::geography;
       CREATE REQUIRED PROPERTY point: ext::postgis::geometry;
+  };
+  CREATE TYPE default::Transaction EXTENDING default::CreatedAt, default::UpdatedAt {
+      CREATE REQUIRED LINK from_wallet: default::Wallet {
+          ON TARGET DELETE RESTRICT;
+      };
+      CREATE REQUIRED LINK to_wallet: default::Wallet {
+          ON TARGET DELETE RESTRICT;
+      };
+      CREATE REQUIRED PROPERTY amount: std::decimal;
+      CREATE REQUIRED PROPERTY confirmed: std::bool {
+          SET default := false;
+      };
+      CREATE PROPERTY confirmed_at: std::datetime;
+      CREATE REQUIRED PROPERTY tx_hash: std::str {
+          CREATE CONSTRAINT std::exclusive;
+      };
   };
   ALTER TYPE default::User {
       CREATE LINK emails := (.<user[IS default::Email]);

--- a/devenv.nix
+++ b/devenv.nix
@@ -28,7 +28,7 @@
   scripts."gelx" = {
     exec = ''
       set -e
-      cargo run --package gelx_cli --bin gelx -- $@
+      cargo run --package gelx_cli --bin gelx -F with_bigdecimal -- $@
     '';
     description = "Install all dependencies.";
   };

--- a/examples/gelx_example/Cargo.toml
+++ b/examples/gelx_example/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true, default-features = true }
 gel-protocol = { workspace = true, default-features = true }
-gelx = { workspace = true, features = ["strum", "builder"] }
+gelx = { workspace = true, features = ["strum", "builder", "with_bigdecimal"] }
 serde = { workspace = true, default-features = true, features = ["derive"] }
 strum = { workspace = true, default-features = true, features = ["derive"] }
 tokio = { workspace = true, default-features = true, features = ["full"] }

--- a/examples/gelx_example/queries/select_transactions.edgeql
+++ b/examples/gelx_example/queries/select_transactions.edgeql
@@ -1,0 +1,3 @@
+select Transaction {
+    *
+} filter .amount = <decimal>$amount;

--- a/examples/gelx_example/src/db/default.rs
+++ b/examples/gelx_example/src/db/default.rs
@@ -169,6 +169,9 @@ mod team {
 mod test_user {
     use super::*;
 }
+mod transaction {
+    use super::*;
+}
 mod user {
     use super::*;
 }

--- a/examples/gelx_example/src/db/mod.rs
+++ b/examples/gelx_example/src/db/mod.rs
@@ -434,6 +434,69 @@ pub mod select_test_user {
     /// The original query string provided to the macro. Can be reused in your codebase.
     pub const QUERY: &str = "select assert_single((\n\tselect TestUser { id, public_id } filter .active and .namelc = str_lower(<str>$username)\n))\n";
 }
+pub mod select_transactions {
+    use ::gelx::exports as __g;
+    /// Execute the desired query.
+    #[cfg(feature = "with_query")]
+    pub async fn query(
+        client: &__g::gel_tokio::Client,
+        props: &Input,
+    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
+        client.query(QUERY, props).await
+    }
+    /// Compose the query as part of a larger transaction.
+    #[cfg(feature = "with_query")]
+    pub async fn transaction(
+        conn: &mut __g::gel_tokio::Transaction,
+        props: &Input,
+    ) -> ::core::result::Result<Vec<Output>, __g::gel_errors::Error> {
+        conn.query(QUERY, props).await
+    }
+    #[derive(::std::fmt::Debug, ::core::clone::Clone, __g::typed_builder::TypedBuilder)]
+    #[cfg_attr(
+        feature = "with_serde",
+        derive(__g::serde::Serialize, __g::serde::Deserialize)
+    )]
+    #[cfg_attr(feature = "with_query", derive(__g::gel_derive::Queryable))]
+    #[builder(crate_module_path = __g::typed_builder)]
+    #[cfg_attr(feature = "with_query", gel(crate_path = __g::gel_protocol))]
+    pub struct Input {
+        #[builder(setter(into))]
+        pub amount: __g::DecimalAlias,
+    }
+    impl __g::gel_protocol::query_arg::QueryArgs for Input {
+        fn encode(
+            &self,
+            encoder: &mut __g::gel_protocol::query_arg::Encoder,
+        ) -> core::result::Result<(), __g::gel_errors::Error> {
+            let map = __g::gel_protocol::named_args! {
+                "amount" => { let value : __g::gel_protocol::model::Decimal = self.amount
+                .clone().try_into().map_err(| e | { <
+                __g::gel_errors::kinds::NumericOutOfRangeError as
+                __g::gel_errors::ErrorKind > ::build() }) ?; value },
+            };
+            map.encode(encoder)
+        }
+    }
+    #[derive(::std::fmt::Debug, ::core::clone::Clone)]
+    #[cfg_attr(
+        feature = "with_serde",
+        derive(__g::serde::Serialize, __g::serde::Deserialize)
+    )]
+    #[cfg_attr(feature = "with_query", derive(__g::gel_derive::Queryable))]
+    #[cfg_attr(feature = "with_query", gel(crate_path = __g::gel_protocol))]
+    pub struct Output {
+        pub created_at: __g::DateTimeAlias,
+        pub id: __g::uuid::Uuid,
+        pub updated_at: __g::DateTimeAlias,
+        pub amount: __g::DecimalAlias,
+        pub confirmed: bool,
+        pub confirmed_at: Option<__g::DateTimeAlias>,
+        pub tx_hash: String,
+    }
+    /// The original query string provided to the macro. Can be reused in your codebase.
+    pub const QUERY: &str = "select Transaction {\n    *\n} filter .amount = <decimal>$amount;";
+}
 pub mod select_user {
     use ::gelx::exports as __g;
     /// Execute the desired query.

--- a/examples/gelx_example/src/lib.rs
+++ b/examples/gelx_example/src/lib.rs
@@ -4,6 +4,7 @@ pub use db::*;
 
 #[cfg(test)]
 mod tests {
+	use gelx::exports::bigdecimal::BigDecimal;
 	use gelx::exports::uuid::Uuid;
 
 	use super::*;
@@ -61,6 +62,21 @@ mod tests {
 			.username("custom")
 			.build();
 		select_test_user::query(&client, &props).await?;
+		Ok(())
+	}
+
+	#[tokio::test]
+	async fn test_select_transactions_query() -> anyhow::Result<()> {
+		let client = Globals::builder()
+			.current_user_id(Uuid::max())
+			.alternative("test")
+			.build()
+			.into_client()
+			.await?;
+		let props = select_transactions::Input::builder()
+			.amount(BigDecimal::from(0))
+			.build();
+		select_transactions::query(&client, &props).await?;
 		Ok(())
 	}
 }


### PR DESCRIPTION
Previously, if input contained an:
- `BigDecimal`
- `chrono::DateTime`
- `BigInt`

codegenerator would emit incorrect code, because `Value` from protocol doesn't implement `From` for those types, but rather `TryFrom`